### PR TITLE
Eleven: Add correct layout for mdpi

### DIFF
--- a/res/layout-mdpi/main_album_flow.xml
+++ b/res/layout-mdpi/main_album_flow.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2012 Andrew Neal
+  Copyright (C) 2014 The CyanogenMod Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<com.cyanogenmod.eleven.widgets.SquareFrame
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="284.0dip"
+    android:layout_height="284.0dip"
+    android:scaleType="fitXY"
+    android:layout_centerInParent="true"
+    android:layout_centerHorizontal="true"
+    android:layout_gravity="center">
+
+    <com.cyanogenmod.eleven.widgets.SquareViewPager
+        android:id="@+id/audio_player_album_art_viewpager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+    <include layout="@layout/loading_empty_container" />
+
+    <View
+        android:id="@+id/equalizerGradient"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/equalizer_background"
+        android:layout_gravity="bottom"/>
+
+    <com.cyanogenmod.eleven.widgets.VisualizerView
+        android:id="@+id/visualizerView"
+        android:gravity="bottom"
+        android:layout_gravity="bottom"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="visible" />
+
+    <TextView
+        android:id="@+id/audio_player_lyrics"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="66dp"
+        android:paddingLeft="15dp"
+        android:paddingRight="15dp"
+        android:paddingTop="6dp"
+        android:paddingBottom="6dp"
+        android:background="@color/lyrics_background_color"
+        android:textColor="@color/white"
+        android:textSize="@dimen/text_size_small"
+        android:alpha="0.0"/>
+</com.cyanogenmod.eleven.widgets.SquareFrame>

--- a/res/values-mdpi/dimens.xml
+++ b/res/values-mdpi/dimens.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2012 Andrew Neal
+     Copyright (C) 2014 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+ -->
+<resources>
+
+    <!-- Audio player Buttons (play/pause/shuffle/repeat/next/previous)-->
+    <dimen name="audio_player_controls_end_button_width">32.0dip</dimen>
+    <dimen name="audio_player_controls_end_button_height">32.0dip</dimen>
+    <dimen name="audio_player_controls_main_button_width">72.0dip</dimen>
+    <dimen name="audio_player_controls_main_button_height">72.0dip</dimen>
+
+    <!-- Header Bar -->
+    <dimen name="header_bar_height">40.0dip</dimen>
+
+</resources>


### PR DESCRIPTION
Fix messed main player window layout for mdpi screens.
Before: 
![screenshot_2015-10-30-11-30-13](https://cloud.githubusercontent.com/assets/2915660/10842732/99e4400c-7efc-11e5-84f7-ec0657a2d882.png)
After:
![screenshot_2015-10-30-11-29-14](https://cloud.githubusercontent.com/assets/2915660/10842736/a1cc9738-7efc-11e5-8880-ea2aa6027f7a.png)

Change-Id: Ibf6f9a5dc4d30e482df9c8cac53fe0283c5dff30
